### PR TITLE
Add GitHub CI to run tox testing across supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Run Tests
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        toxenv: [py3]
+        #if had separate tox envs -- could add here
+        #include:
+        # - python-version: "3.10"
+        #   toxenv: lint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: |
+          pip install --upgrade pip
+          pip install tox
+      - name: Run tests
+        run: tox -e ${{ matrix.toxenv }}

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ basepython=python3
 deps =
     {[deps]test}
 
-[testenv:py{38,39,310}]
+[testenv:py{39,310,311}]
 deps =
     {[deps]test}
 


### PR DESCRIPTION
There is some oddity in testing since it did fail once in 3.12 and another time didn't in my fork https://github.com/yarikoptic/bids-pydantic/actions/runs/7806555933/job/21293169855 although 

```
pylint crashed with a ``AstroidError`` and with the following stacktrace:
```

I would recommend separating tox testing into separate jobs for pylinting etc... Adding GitHub CI has provision to add more tox envs to test through